### PR TITLE
feat: add config to ignore unsupported image

### DIFF
--- a/packages/markitup/src/markitup/_schemas.py
+++ b/packages/markitup/src/markitup/_schemas.py
@@ -23,6 +23,7 @@ class Config(BaseModel):
     tiktoken_encoder: str = TIKTOKEN_ENCODER
     image_use_webp: bool = True  # TODO: support files contains images
     image_max_width_or_height: int = 768
+    ignore_unsupported_image: bool = False
 
 
 class BBox(BaseModel):


### PR DESCRIPTION
### **User description**
Add a new config, so for PPTX files containing image/x-wmf, we can safely ignore those images and preserve the rest of the content.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `ignore_unsupported_image` configuration option

- Implement error handling for unsupported image formats

- Convert failed images to descriptive text chunks

- Preserve document processing when images fail


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Config Schema"] --> B["ignore_unsupported_image flag"]
  B --> C["Base Converter"]
  C --> D["Image Processing"]
  D --> E{"Image Supported?"}
  E -->|Yes| F["Image Chunk"]
  E -->|No + Flag True| G["Text Chunk with Error"]
  E -->|No + Flag False| H["Raise Exception"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_base_converter.py</strong><dd><code>Implement error handling for unsupported images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/markitup/src/markitup/_base_converter.py

<li>Add try-catch blocks around <code>_process_image()</code> calls<br> <li> Check <code>ignore_unsupported_image</code> config flag on exceptions<br> <li> Convert unsupported images to text chunks with error messages<br> <li> Apply error handling in both chunked and full markdown processing


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/markitup/pull/14/files#diff-18ec07da485542da5069461df0a575d2905c1c5d7f05ac51d345f6d02c5bb088">+36/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_schemas.py</strong><dd><code>Add ignore unsupported image configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/markitup/src/markitup/_schemas.py

<li>Add <code>ignore_unsupported_image</code> boolean field to Config class<br> <li> Default value set to False for backward compatibility


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/markitup/pull/14/files#diff-17bd892283cf6fbcab0c18d8f13d9a387aa19aa6902ed10153bebfe85277986c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>